### PR TITLE
Reset error when url change

### DIFF
--- a/src/lib/useImageSize.ts
+++ b/src/lib/useImageSize.ts
@@ -11,6 +11,7 @@ export const useImageSize = (url: string, options?: Options): UseImageSizeResult
     const fetch = async () => {
       setLoading(true);
       setDimensions(null);
+      setError(null);
 
       try {
         const { width, height } = await getImageSize(url, options);


### PR DESCRIPTION
first i put an error image url, then got an error info from useImageSize hook, but when i update the url, error still old